### PR TITLE
Serial.write error fixed

### DIFF
--- a/Arduino_IDE/client/client.ino
+++ b/Arduino_IDE/client/client.ino
@@ -57,16 +57,16 @@ void GXTRACE(const char* str, const char* data)
 {
   //Send trace to the serial port.
   byte c;
-  Serial1.write("\t:", 2);
+  Serial1.write("\t:");
   while ((c = pgm_read_byte(str++)) != 0)
   {
     Serial1.write(c);
   }
   if (data != NULL)
   {
-    Serial1.write(data, strlen(data));
+    Serial1.write(data);
   }
-  Serial1.write("\0", 1);
+  Serial1.write("\0");
   //Serial1.flush();
   delay(10);
 }


### PR DESCRIPTION
 Serial.write function can send single and multiple byte without second argument for detial you can check this link  https://www.arduino.cc/reference/en/language/functions/communication/serial/write/