### PR TITLE
Fix value truncation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.20)
+project(dlms_c VERSION 1.0)
+
+add_subdirectory(development)
+add_subdirectory(GuruxDLMSServerExample)
+add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.12)
 project(dlms_c VERSION 1.0)
 
 add_subdirectory(development)
 add_subdirectory(GuruxDLMSServerExample)
-add_subdirectory(test)

--- a/GuruxDLMSServerExample/CMakeLists.txt
+++ b/GuruxDLMSServerExample/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.12)
 project(dlms_c VERSION 1.0)
 
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")

--- a/GuruxDLMSServerExample/CMakeLists.txt
+++ b/GuruxDLMSServerExample/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.20)
+project(dlms_c VERSION 1.0)
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -fPIC")
+
+add_compile_definitions(DLMS_USE_EPOCH_TIME)
+
+add_executable(dlms_server1 src/connection.c
+        src/exampleserver.c
+        src/getopt.c
+        src/main.c)
+
+link_directories(../development)
+target_link_libraries(dlms_server1 PUBLIC dlms m)

--- a/GuruxDLMSServerExample/src/exampleserver.c
+++ b/GuruxDLMSServerExample/src/exampleserver.c
@@ -2620,7 +2620,7 @@ void svr_preAction(
                 }
                 info->identification.size = size;
 #if defined(_WIN32) || defined(_WIN64) || defined(__linux__)//If Windows or Linux
-                printf("Updating image %s Size: %d\r\n", imageFile, info->size);
+                printf("Updating image %s Size: %ld\r\n", imageFile, info->size);
 #endif
                 allocateImageTransfer(imageFile, info->size);
                 ba_clear(&i->imageTransferredBlocksStatus);
@@ -2926,7 +2926,7 @@ int sendPush(
     {
         return DLMS_ERROR_CODE_INVALID_PARAMETER;
     }
-    pos = (int)(p - push->destination.data);
+    pos = (int)(p - (char *)push->destination.data);
     host = (char*)malloc(pos + 1);
     memcpy(host, push->destination.data, pos);
     host[pos] = '\0';

--- a/GuruxDLMSServerExample/src/main.c
+++ b/GuruxDLMSServerExample/src/main.c
@@ -167,7 +167,7 @@ int startServers(int port, int trace)
             }
         }
 #else
-        char ch = _getch();
+        char ch = getchar();
         if (ch == '\n')
         {
             printf("Closing the server.\n");
@@ -176,6 +176,7 @@ int startServers(int port, int trace)
 #endif
     }
     con_close(&snHdlc);
+    con_close(&lnHdlc);
     con_close(&snWrapper);
     con_close(&lnWrapper);
     return 0;
@@ -283,6 +284,7 @@ int main(int argc, char* argv[])
             return 1;
         }
     }
+    trace = GX_TRACE_LEVEL_ERROR;
     startServers(port, trace);
 #if defined(_WIN32) || defined(_WIN64)//Windows
 

--- a/development/CMakeLists.txt
+++ b/development/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.20)
+project(dlms_c VERSION 1.0)
+
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -fPIC")
+add_compile_definitions(DLMS_USE_EPOCH_TIME)
+
+add_library(dlms STATIC
+        src/apdu.c
+        src/dlms.c
+        src/gxserializer.c
+        src/notify.c
+        src/bitarray.c
+        src/dlmsSettings.c
+        src/gxset.c
+        src/objectarray.c
+        src/bytebuffer.c
+        src/gxaes.c
+        src/gxsetignoremalloc.c
+        src/parameters.c
+        src/ciphering.c
+        src/gxarray.c
+        src/gxsetmalloc.c
+        src/replydata.c
+        src/client.c
+        src/gxget.c
+        src/gxsha1.c
+        src/server.c
+        src/converters.c
+        src/gxinvoke.c
+        src/gxsha256.c
+        src/serverevents.c
+        src/cosem.c
+        src/gxkey.c
+        src/gxvalueeventargs.c
+        src/variant.c
+        src/datainfo.c
+        src/gxmd5.c
+        src/helpers.c
+        src/date.c
+        src/gxobjects.c
+        src/message.c
+        )
+
+target_include_directories(dlms PUBLIC include)

--- a/development/CMakeLists.txt
+++ b/development/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.12)
 project(dlms_c VERSION 1.0)
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -fPIC")

--- a/development/include/cosem.h
+++ b/development/include/cosem.h
@@ -46,9 +46,9 @@ extern "C" {
       gxObject** object);
 
   int cosem_createObject2(
-      DLMS_OBJECT_TYPE type,
-      const char* ln,
-      gxObject** object);
+          DLMS_OBJECT_TYPE type,
+          const uint8_t *ln,
+          gxObject** object);
 #endif //DLMS_IGNORE_MALLOC
 
   int cosem_setLogicalName(

--- a/development/include/cosem.h
+++ b/development/include/cosem.h
@@ -59,25 +59,25 @@ extern "C" {
   int cosem_init(
       gxObject* object,
       DLMS_OBJECT_TYPE type,
-      const char* logicalNameString);
+      uint8_t* logicalNameString);
 #endif //DLMS_IGNORE_MALLOC
 
   int cosem_init2(
     gxObject* object,
     DLMS_OBJECT_TYPE type,
-    const unsigned char* ln);
+    const uint8_t * ln);
 
   //This initialize method will also check the size of the object type and compare it with the expected size.
   int cosem_init3(
       gxObject* object,
-      const unsigned char expectedSize,
+      uint16_t expectedSize,
       DLMS_OBJECT_TYPE type,
       const unsigned char* ln);
 
   //This initialize method will also check the size of the object type and compare it with the expected size.
   int cosem_init4(
       void* object,
-      const unsigned char expectedSize,
+      uint16_t expectedSize,
       DLMS_OBJECT_TYPE type,
       const unsigned char* ln);
 

--- a/development/include/gxobjects.h
+++ b/development/include/gxobjects.h
@@ -586,16 +586,15 @@ extern "C" {
         * Base class where class is derived.
         */
         gxObject base;
-
+        gxtime time;
+        gxtime begin;
+        gxtime end;
+        gxtime presetTime;
+        DLMS_CLOCK_STATUS status;
         DLMS_CLOCK_BASE clockBase;
+        int16_t timeZone;
         signed char deviation;
         unsigned char enabled;
-        gxtime end;
-        DLMS_CLOCK_STATUS status;
-        gxtime begin;
-        int16_t timeZone;
-        gxtime time;
-        gxtime presetTime;
     } gxClock;
 
 #ifndef DLMS_IGNORE_CLOCK

--- a/development/include/helpers.h
+++ b/development/include/helpers.h
@@ -130,7 +130,7 @@ static const unsigned char EMPTY_KEY[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 
 #if !defined(DLMS_IGNORE_MALLOC)
     //Set logical name from string.
-    int hlp_setLogicalName(unsigned char ln[6], const char* name);
+    int hlp_setLogicalName(unsigned char ln[6], const uint8_t *name);
 #endif //!defined(DLMS_IGNORE_MALLOC)
 
 #if !defined(DLMS_IGNORE_STRING_CONVERTER) && !defined(DLMS_IGNORE_MALLOC)
@@ -139,7 +139,7 @@ static const unsigned char EMPTY_KEY[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     int hlp_parseLogicalName(gxByteBuffer* value, unsigned char ln[6]);
 
     //Set logical name from string.
-    int hlp_setLogicalName2(dlmsVARIANT* ln, const char* name);
+    int hlp_setLogicalName2(dlmsVARIANT* ln, const uint8_t *name);
 
     int hlp_appendLogicalName(gxByteBuffer* bb, const unsigned char value[6]);
 

--- a/development/src/cosem.c
+++ b/development/src/cosem.c
@@ -480,7 +480,7 @@ int cosem_setLogicalName(
 int cosem_init(
     gxObject* object,
     DLMS_OBJECT_TYPE type,
-    const char* logicalNameString)
+    uint8_t * logicalNameString)
 {
     unsigned char ln[6];
     hlp_setLogicalName(ln, logicalNameString);
@@ -498,7 +498,7 @@ int cosem_init2(
 
 int cosem_init3(
     gxObject* object,
-    const unsigned char expectedSize,
+    const uint16_t expectedSize,
     DLMS_OBJECT_TYPE type,
     const unsigned char* ln)
 {
@@ -507,7 +507,7 @@ int cosem_init3(
 
 int cosem_init4(
     void* object,
-    const unsigned char expectedSize,
+    uint16_t expectedSize,
     DLMS_OBJECT_TYPE type,
     const unsigned char* ln)
 {

--- a/development/src/cosem.c
+++ b/development/src/cosem.c
@@ -454,9 +454,9 @@ int cosem_createObject(DLMS_OBJECT_TYPE type, gxObject** object)
 }
 
 int cosem_createObject2(
-    DLMS_OBJECT_TYPE type,
-    const char* ln,
-    gxObject** object)
+        DLMS_OBJECT_TYPE type,
+        const uint8_t *ln,
+        gxObject** object)
 {
     int ret = cosem_createObject(type, object);
     if (ret != 0)
@@ -480,7 +480,7 @@ int cosem_setLogicalName(
 int cosem_init(
     gxObject* object,
     DLMS_OBJECT_TYPE type,
-    uint8_t * logicalNameString)
+    uint8_t* logicalNameString)
 {
     unsigned char ln[6];
     hlp_setLogicalName(ln, logicalNameString);

--- a/development/src/helpers.c
+++ b/development/src/helpers.c
@@ -656,7 +656,7 @@ int hlp_parseLogicalName(gxByteBuffer* value, unsigned char ln[6])
 }
 
 //Set logical name from string.
-int hlp_setLogicalName2(dlmsVARIANT* ln, const char* name)
+int hlp_setLogicalName2(dlmsVARIANT* ln, const uint8_t *name)
 {
     int ret;
     unsigned char tmp[6];
@@ -762,12 +762,12 @@ int hlp_getLogicalNameToString(const unsigned char value[6], char* ln)
 
 #if !defined(DLMS_IGNORE_MALLOC)
 //Set logical name from string.
-int hlp_setLogicalName(unsigned char ln[6], const char* name)
+int hlp_setLogicalName(unsigned char ln[6], const uint8_t *name)
 {
     char* ch;
     char* pOriginalBuff;
     char* pBuff;
-    int val = 0, count = 0, size = (int)strlen(name);
+    int val = 0, count = 0, size = (int)strlen((char *)name);
     if (size < 11)
     {
         return -1;


### PR DESCRIPTION
The size of the data type in the function parameters is smaller than the value that can be passed. Consequently, there was a reduction. Example: sizeof(gxclock) = 304 is truncated and becomes 48, which was passed to the cosem_init4() function.