### PR TITLE
build(development/makefile): add obj and lib directories recipes

### DIFF
--- a/development/makefile
+++ b/development/makefile
@@ -24,15 +24,24 @@ SOURCES  := $(wildcard $(SRCDIR)/*.c)
 INCLUDES := $(wildcard $(SRCDIR)/*.h)
 OBJECTS  := $(SOURCES:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
 rm       = rm -f
+md       = mkdir
 
 
-$(BINDIR)/$(TARGET): $(OBJECTS)
+$(BINDIR)/$(TARGET): $(BINDIR) $(OBJDIR) $(OBJECTS)
 	@$(LINKER) $@ $(LFLAGS) $(OBJECTS)
 	@echo "Linking complete!"
 
 $(OBJECTS): $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	@$(CC) $(CFLAGS) -c $< -o $@
 	@echo "Compiled "$<" successfully!"
+
+$(OBJDIR):
+	@$(md) $@
+	@echo Created $@
+
+$(BINDIR):
+	@$(md) $@
+	@echo Created $@
 
 .PHONEY: clean
 clean:
@@ -44,3 +53,4 @@ clean:
 remove: clean
 	@$(rm) $(BINDIR)/$(TARGET)
 	@echo "Executable removed!"
+


### PR DESCRIPTION
Currently, to build DLMS.c as a ststaic library, one needs to make in the development directory. But the makefile assumes the lib and obj directories already exists. if they are not created before running make, an error is thrown. This change adds recipes to create the directories if they don't exist.

- Add recipes for `OBJDIR` and `BINDIR` directories
- Add `OBJDIR` and `BINDIR` as dependencies to library recipe
- Added `md` variable to use platform's command to create directories