### PR TITLE
fix(development/include/gxinvoke.h): `DLMS_IGNORE_SERVER` causes build error (missing bracket `}`)

### DIFF
--- a/development/include/gxinvoke.h
+++ b/development/include/gxinvoke.h
@@ -62,9 +62,9 @@ extern "C" {
         gxValueEventArg* e);
 #endif //DLMS_IGNORE_SCRIPT_TABLE
 
+#endif //DLMS_IGNORE_SERVER
 #ifdef  __cplusplus
 }
 #endif
-#endif //DLMS_IGNORE_SERVER
 
 #endif //COSEM_INVOKE_H


### PR DESCRIPTION
## TLDR 
In `gxinvoke.h` the `#endif //DLMS_IGNORE_SERVER` was placed before the linkage scope closing bracket.

## Details

In `gxinvoke.h` there's an overlap between the `DLMS_IGNORE_SERVER` and the `C` linkage definitons. They are opened and closed in different order. Which leaves an un-closed linkage scope, when `DLMS_IGNORE_SERVER` is defined.
