### PR TITLE
fix(development/include/variant.h): build error on Arduino with STM32 target

### DIFF
--- a/development/include/variant.h
+++ b/development/include/variant.h
@@ -30,8 +30,8 @@
 // Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 //---------------------------------------------------------------------------
 
-#ifndef VARIANT_H
-#define VARIANT_H
+#ifndef GX_VARIANT_H
+#define GX_VARIANT_H
 
 #ifdef  __cplusplus
 extern "C" {
@@ -608,4 +608,4 @@ extern "C" {
 }
 #endif
 
-#endif //VARIANT_H
+#endif //GX_VARIANT_H


### PR DESCRIPTION
## TLDR

`variant.h` header guard was changed to `GX_VARIANT_H_`.

## Details

STM32 libraries use the `VARIANT_H_` definition during build. This causes the header file `variant.h`, which uses the same definition as a header guard, to be included empty. Resulting in multiple build errors (unknown types, etc). Header guard was changed to `GX_VARIANT_H_`.

