### PR TITLE
Fix out-of-bounds read by clearing attribute descriptor

### DIFF
--- a/development/src/dlms.c
+++ b/development/src/dlms.c
@@ -6154,6 +6154,15 @@ int dlms_getLnMessages(
             {
                 ++p->settings->blockIndex;
             }
+            else
+            {
+                // Attribute descriptor is included only in the first data block
+                // (SET-Request-First-DataBlock). Clear the reference so that
+                // subsequent blocks (SET-Request-With-DataBlock) do not attempt
+                // to re-add it, which would cause an out-of-bounds read because
+                // bb_set2 has already advanced the buffer position past its end.
+                p->attributeDescriptor = NULL;
+            }
         }
         while (ret == 0 && pdu->position != pdu->size)
         {


### PR DESCRIPTION
## Description

**Bug:** An out-of-bounds read occurs in `dlms_getLnMessages()` when sending a SET request that spans multiple data blocks.

**Root cause:** The attribute descriptor is correctly included only in the first data block (SET-Request-First-DataBlock). However, `p->attributeDescriptor` was not cleared afterwards. When subsequent blocks (SET-Request-With-DataBlock) were being built, the code attempted to re-add the attribute descriptor, but `bb_set2` had already advanced the buffer position past its end, causing an out-of-bounds read.

**Fix:** Added an `else` branch after the first-block case in `development/src/dlms.c` that sets `p->attributeDescriptor = NULL`. This ensures subsequent blocks no longer attempt to include the descriptor, preventing the out-of-bounds access.

## Affected file

`development/src/dlms.c` — function `dlms_getLnMessages()`

## How to reproduce

Send a SET request with a value large enough to require more than one data block (SET-Request-With-DataBlock). The out-of-bounds read occurs when building the second and subsequent blocks.

## Testing

Verified that multi-block SET requests complete successfully after the fix, and single-block SET requests are unaffected.